### PR TITLE
feat: show selected bowl volume dynamically in CenterBowl

### DIFF
--- a/src/components/CenterBowl.tsx
+++ b/src/components/CenterBowl.tsx
@@ -5,6 +5,7 @@ function CenterBowl() {
   const setBaseType = useIngredientStore((s) => s.setBaseType)
   const slots = useIngredientStore((s) => s.slots)
   const clearSelection = useIngredientStore((s) => s.clearSelection)
+  const selectedBowl = useIngredientStore((s) => s.selectedBowl)
 
   const activeIngredients = Object.values(slots).filter((i) => i !== null)
 
@@ -75,7 +76,7 @@ function CenterBowl() {
       
       <div className="mt-6 text-center text-sm text-gray-600">
         <p>100 g / 1,99 €</p>
-        <p>500 ml</p>
+        <p>{selectedBowl ? selectedBowl.volume : 0} ml</p>
       </div>
 
     </div>


### PR DESCRIPTION
## Summary
- Read `selectedBowl` from `useIngredientStore` in `CenterBowl.tsx`
- Replaced static `500 ml` text with `{selectedBowl ? selectedBowl.volume : 0} ml`

## Test plan
- [ ] Select a bowl from BowlSelection — volume should update under the center graphic
- [ ] With no bowl selected, volume should display `0 ml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)