### PR TITLE
Task 5.2: Implement Login Logic in LoginModal

### DIFF
--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import Modal from './Modal';
+import { login as loginApi } from '../services/api';
+import { useAuthStore } from '../store/useAuthStore';
 
 interface Props {
   isOpen: boolean;
@@ -9,12 +11,22 @@ interface Props {
 function LoginModal({ isOpen, onClose }: Props) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const login = useAuthStore((s) => s.login);
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    console.log('Login clicked');
-    setEmail('');
-    setPassword('');
+    setError('');
+
+    try {
+      const data = await loginApi(email, password);
+      login(data.token, data.name);
+      setEmail('');
+      setPassword('');
+      onClose();
+    } catch {
+      setError('Invalid email or password.');
+    }
   }
 
   return (
@@ -45,6 +57,8 @@ function LoginModal({ isOpen, onClose }: Props) {
             required
           />
         </div>
+
+        {error && <p className="text-red-500 text-sm">{error}</p>}
 
         <button
           type="submit"

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,18 @@
 const BASE_URL = "https://fresse-api.onrender.com/api";
 
+// Login
+export async function login(email: string, password: string) {
+  const res = await fetch(`${BASE_URL}/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!res.ok) throw new Error("Invalid credentials");
+
+  return await res.json();
+}
+
 // Get Bowls
 export async function getBowls() {
   try {


### PR DESCRIPTION
## Summary
- Added `login(email, password)` function to `src/services/api.ts` — makes a POST request to `/api/auth/login`
- Updated `LoginModal.tsx` to call the API on form submit
- On success: saves `token` and `name` to AuthStore, clears inputs, closes modal
- On failure: displays a red error message `Invalid email or password.`

Closes #86

## Test plan
- [ ] Submit with valid credentials — modal closes, session saved to localStorage
- [ ] Submit with wrong credentials — red error message appears
- [ ] Refresh page after login — session should still be active (from AuthStore + localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)