### PR TITLE
feat: Task 6.2 - Refactor Base Ingredients API

### DIFF
--- a/src/components/BaseSelection.tsx
+++ b/src/components/BaseSelection.tsx
@@ -1,13 +1,10 @@
 import type { Ingredient } from "../types/index"
 
 interface Props {
-  ingredients?: Ingredient[]
+  bases?: Ingredient[]
 }
 
-function BaseSelection({ ingredients = [] }: Props) {
-
-  // Filter only base ingredients (categoryId === 6)
-  const bases = ingredients.filter(i => i.categoryId === 6)
+function BaseSelection({ bases = [] }: Props) {
 
   return (
     <div className="bg-zinc-800 rounded-[3rem] p-6 text-white w-full lg:w-1/4 flex flex-col items-center shadow-lg">

--- a/src/pages/Configurator.tsx
+++ b/src/pages/Configurator.tsx
@@ -8,12 +8,13 @@ import Modal from '../components/Modal'
 import { useIngredientStore } from '../store/useIngredientStore'
 
 import type { Bowl, Category, Ingredient } from '../types/index'
-import { getBowls, getCategories, getIngredients } from '../services/api'
+import { getBowls, getCategories, getIngredients, getBaseIngredients } from '../services/api'
 
 function Configurator() {
   const [bowls, setBowls] = useState<Bowl[]>([])
   const [categories, setCategories] = useState<Category[]>([])
   const [ingredients, setIngredients] = useState<Ingredient[]>([])
+  const [bases, setBases] = useState<Ingredient[]>([])
 
   const [loading, setLoading] = useState(true)
 
@@ -24,15 +25,17 @@ function Configurator() {
   useEffect(() => {
     async function loadData() {
       try {
-        const [b, c, i] = await Promise.all([
+        const [b, c, i, bi] = await Promise.all([
           getBowls(),
           getCategories(),
-          getIngredients()
+          getIngredients(),
+          getBaseIngredients()
         ])
 
         setBowls(b)
         setCategories(c)
         setIngredients(i)
+        setBases(bi)
       } catch (error) {
         console.error(error)
       } finally {
@@ -58,7 +61,7 @@ function Configurator() {
       <div className="flex flex-col lg:flex-row gap-6">
         <BowlSelection bowls={bowls.filter(b => b.base_type_id === baseType)} />
         <CenterBowl />
-        <BaseSelection ingredients={ingredients} />
+        <BaseSelection bases={bases} />
       </div>
 
       <IngredientSection

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -37,6 +37,18 @@ export async function getCategories() {
   }
 }
 
+// Get Base Ingredients
+export async function getBaseIngredients() {
+  try {
+    const res = await fetch(`${BASE_URL}/baseingredients`);
+    if (!res.ok) throw new Error("Failed to fetch base ingredients");
+    return await res.json();
+  } catch (error) {
+    console.error("getBaseIngredients error:", error);
+    return [];
+  }
+}
+
 // Get Ingredients
 export async function getIngredients() {
   try {


### PR DESCRIPTION
## Summary
- Added `getBaseIngredients()` in `api.ts` fetching from `/api/baseingredients`
- Added dedicated `bases` state in `Configurator.tsx`, fetched in parallel with other data
- Passed `bases` directly to `BaseSelection`, removing the old `.filter(categoryId === 6)` logic

## Test plan
- [ ] Salad/Quark bases load correctly from the new `/api/baseingredients` endpoint
- [ ] BaseSelection displays bases as before
- [ ] No regression in other sections (BowlSelection, IngredientSection)

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)