### PR TITLE
feat: Task 6.4 - Smart Click-to-Add & Slot Logic (Store)

### DIFF
--- a/src/store/useIngredientStore.ts
+++ b/src/store/useIngredientStore.ts
@@ -11,6 +11,7 @@ interface IngredientStore {
   clearSelection: () => void;
   addIngredient: (item: Ingredient) => void;
   removeIngredient: (id: string) => void;
+  clearSlot: (slotId: string) => void;
 }
 
 export const useIngredientStore = create<IngredientStore>((set) => ({
@@ -87,4 +88,9 @@ export const useIngredientStore = create<IngredientStore>((set) => ({
 
       return { slots: newSlots };
     }),
+
+  clearSlot: (slotId) =>
+    set((state) => ({
+      slots: { ...state.slots, [slotId]: null },
+    })),
 }));


### PR DESCRIPTION
## Summary
- `slots: Record<string, Ingredient | null>` state was already in place
- `addIngredient` already loops from 1 to `selectedBowl.slot_count`, fills the first `null` slot, and does nothing if all slots are full
- Added `clearSlot(slotId: string)` to the interface and store implementation — nulls out a specific slot by key

## Test plan
- [ ] Clicking an ingredient fills the next available slot automatically
- [ ] Clicking when all slots are full does nothing
- [ ] `clearSlot` correctly empties a specific slot (ready for CenterBowl to use)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)